### PR TITLE
Trim the xcffib reply to 4 bytes to avoid an unpacking error

### DIFF
--- a/runekit/game/x11/manager.py
+++ b/runekit/game/x11/manager.py
@@ -102,7 +102,7 @@ class X11GameManager(GameManager):
         if reply.type == xcffib.xproto.Atom.STRING:
             return reply.value.to_string()[:-1]
         elif reply.type in (xcffib.xproto.Atom.WINDOW, xcffib.xproto.Atom.CARDINAL):
-            return struct.unpack("=I", reply.value.buf())[0]
+            return struct.unpack("=I", reply.value.buf()[:4])[0]
 
         return reply.value
 


### PR DESCRIPTION
I kept getting a "struct.error: unpack requires a buffer of 4 bytes"
upon launch. After some quick investigation I found out that this buffer
for me would contain something like b'\x03\x00\xc0\x07\x00\x00\x00\x00'.
Where the last 4 bytes would always be 0. This patch simply trims this
buffer to the first 4 bytes, after which everything started working on
my setup.

I have no real clue why it's even 8 bytes for me to begin with, it's a pretty stock Ubuntu 20.04 installation. There probably is a better solution of solving this, but this seems to work.