### PR TITLE
Update lastGameActivity upon focus

### DIFF
--- a/runekit/browser/alt1.js
+++ b/runekit/browser/alt1.js
@@ -385,6 +385,7 @@
 
             if(active){
                 emit({eventName: 'rsfocus'});
+                lastGameActivity = window.performance.now();
             }else{
                 emit({eventName: 'rsblur'});
             }


### PR DESCRIPTION
So, the lobby timer in afk warden wasn't working for me at all. I assume the following is supposed to be called upon focus
```javascript
instance.game_activity_signal.connect(function(){
   lastGameActivity = window.performance.now();
});
```
Upon some investigating however it seems like this isn't being called, or at least not reliably. By updating from the callback a bit higher up (as seen in the pull request) it does seem to be updated more reliably.