### PR TITLE
sc - dont open cors in browser because it breaks afk warden

### DIFF
--- a/runekit/app/view/browser_window.py
+++ b/runekit/app/view/browser_window.py
@@ -43,16 +43,17 @@ class PageClass(QWebEnginePage):
         if not is_main_frame:
             return super().acceptNavigationRequest(url, type_, is_main_frame)
 
-        if (
-            type_ != QWebEnginePage.NavigationTypeTyped
-            and url.authority() != self.url().authority()
-        ):
-            # The web is only allowed pages on the same origin
-            # Cross origin pages would open in browser
-            if url.scheme() in ("http", "https"):
-                QDesktopServices.openUrl(url)
+        # This breaks AFK Warden popups
+        # if (
+        #     type_ != QWebEnginePage.NavigationTypeTyped
+        #     and url.authority() != self.url().authority()
+        # ):
+        #     # The web is only allowed pages on the same origin
+        #     # Cross origin pages would open in browser
+        #     if url.scheme() in ("http", "https"):
+        #         QDesktopServices.openUrl(url)
 
-            return False
+        #     return False
 
         return super().acceptNavigationRequest(url, type_, is_main_frame)
 


### PR DESCRIPTION
This is definitely a first draft, but this change fixes afk warden on macs at the moment.

Some things we can do to limit this change's effect:

- make sure it's mac only
- make sure it's only for the afk warden app

Let me know what you think @whs.