### PR TITLE
Use Option for macOS instead of cmd

### DIFF
--- a/runekit/game/quartz/manager.py
+++ b/runekit/game/quartz/manager.py
@@ -123,11 +123,11 @@ class QuartzGameManager(GameManager):
         if not instance:
             return event
 
-        # Check for cmd1
+        # Check for option+1
         if nsevent.type() == Quartz.NSEventTypeKeyDown:
             if (
                 nsevent.keyCode() == 18
-                and nsevent.modifierFlags() & Quartz.NSEventModifierFlagCommand
+                and nsevent.modifierFlags() & Quartz.NSEventModifierFlagOption
             ):
                 instance.alt1_pressed.emit()
                 return None


### PR DESCRIPTION
Generally on macOS `Option` is used as a substitute for `ALT`, whereas `CMD` is generally used in place of `CTRL` (you use CMD+C for copy, etc).

Most people I've spoken to just assumed the key binding doesn't work seeing as it didn't work with `Option`, so figured it makes sense to just update it here to avoid confusion :) 